### PR TITLE
fix: Initial commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,20 +40,30 @@ Greet someone
 ### Example usage
 
 ```yaml
-on: [push]
-
+name: Deploy via Pulumi
+on: # only trigger on prs to main closed
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
 jobs:
-  hello_world_job:
+  deploy:
+    if: github.event.pull_request.merged == true # only deploy on merged PRs
+    strategy:
+      matrix:
+        stack-name: [ common, nonprod, prod ]
+    name: Deploy ${{ matrix.stack-name }}
     runs-on: ubuntu-latest
-    name: A job to say hello
     steps:
-      - uses: actions/checkout@v2
-      - id: foo
-        uses: actions/hello-world-composite-action@v1
+      - name: Deploy
+        uses: catalystsquad/action-pulumi@v1
         with:
-          who-to-greet: "Mona the Octocat"
-      - run: echo random-number ${{ steps.foo.outputs.random-number }}
-        shell: bash
+          command: up
+          stack-name: ${{ matrix.stack-name }}
+          aws-access-key-id: ${{ secrets.PULUMI_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.PULUMI_AWS_SECRET_ACCESS_KEY }}
+          cloud-url: ${{ secrets.PULUMI_BACKEND_URL_PLATFORM }}
 ```
 
 <!-- end examples -->

--- a/action.yaml
+++ b/action.yaml
@@ -1,22 +1,136 @@
-name: 'Hello World' # taken from https://docs.github.com/en/actions/creating-actions/creating-a-composite-action
-description: 'Greet someone'
+name: 'Run Pulumi Command'
+description: Runs pulumi command on specified stack. Currently supports pulumi in golang and AWS, may support other languages and providers in the future. If the runtime is go, then go modules are cached.
 inputs:
-  who-to-greet:  # id of input
-    description: 'Who to greet'
+  runtime:
+    description: Pulumi runtime
+    required: false
+    default: go
+  go-version:
+    description: Go version to use, this input is only used if the runtime is set to `go`
+    required: false
+    default: '~1.17'
+  provider:
+    description: Cloud provider to get credentials for
+    required: false
+    default: aws
+  aws-region:
+    description: AWS region
+    required: false
+    default: us-west-2
+  aws-access-key-id:
+    description: AWS access key id to use
+    required: false
+    default: ''
+  aws-secret-access-key:
+    description: AWS secret access key
+    required: false
+    default: ''
+  command:
+    description: 'Pulumi command to run, one of `up`, `refresh`, `destroy`, `preview`'
     required: true
-    default: 'World'
+  stack-name:
+    description: 'Which stack you want to apply to, eg. prod'
+    required: true
+  work-dir:
+    description: 'Location of your Pulumi files. Defaults to ./'
+    required: false
+    default: ./
+  comment-on-pr:
+    description: 'If true, a comment will be created with results'
+    required: false
+    default: 'false'
+  github-token:
+    description: 'Github Token'
+    required: false
+    default: ${{ github.token }}
+  cloud-url:
+    description: 'A cloud URL to log in to'
+    required: false
+    default: ''
+  secrets-provider:
+    description: 'The type of the provider that should be used to encrypt and decrypt secrets. Possible choices: default, passphrase, awskms, azurekeyvault, gcpkms, hashivault'
+    required: false
+    default: ''
+  parallel:
+    description: 'Allow P resource operations to run in parallel at once (1 for no parallelism). Defaults to unbounded.'
+    required: false
+    default: '2147483647'
+  message:
+    description: 'Optional message to associate with the update operation'
+    required: false
+    default: ''
+  expect-no-changes:
+    description: 'Return an error if any changes occur during this update'
+    required: false
+  diff:
+    description: 'Display operation as a rich diff showing the overall change'
+    required: false
+  replace:
+    description: 'Specify resources to replace. Multiple resources can be specified one per line'
+    required: false
+  target:
+    description: 'Specify a single resource URN to update. Other resources will not be updated. Multiple resources can be specified one per line'
+    required: false
+  target-dependents:
+    description: 'Allows updating of dependent targets discovered but not specified in target.'
+    required: false
+    default: 'false'
+  refresh:
+    description: 'Perform a stack refresh as part of the operation'
+    required: false
+    default: 'false'
+  upsert:
+    description: 'Create the stack if it currently does not exist'
+    required: false
+    default: 'false'
+  edit-pr-comment:
+    description: 'Edit previous PR comment instead of posting new one'
+    required: false
+    default: 'true'
 outputs:
-  random-number:
-    description: "Random number"
-    value: ${{ steps.random-number-generator.outputs.random-id }}
+  command-output:
+    description: "Output of pulumi command"
+    value: ${{ steps.command.outputs.output }}
 runs:
   using: "composite"
   steps:
-    - run: echo Hello ${{ inputs.who-to-greet }}.
+    - name: Checkout
+      uses: actions/checkout@v2
+    - if: inputs.provider == 'aws'
+      name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-region: ${{ inputs.aws-region }}
+        aws-access-key-id: ${{ inputs.aws-access-key-id }}
+        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
+    - if: inputs.runtime == 'go'
+      name: Setup Go With Caching
+      uses: magnetikonline/action-golang-cache@v1
+      with:
+        go-version: ${{ inputs.go-version }}
+    - if: inputs.runtime == 'go'
+      name: Download go dependencies
       shell: bash
-    - id: random-number-generator
-      run: echo "::set-output name=random-id::$(echo $RANDOM)"
-      shell: bash
-    - run: ${{ github.action_path }}/goodbye.sh
-      shell: bash
-
+      run: | 
+        go mod download
+    - name: Run Pulumi command
+      id: command
+      uses: pulumi/actions@v3
+      with:
+        command: ${{ inputs.command }}
+        stack-name: ${{ inputs.stack-name }}
+        work-dir: ${{ inputs.work-dir }}
+        comment-on-pr: ${{ inputs.comment-on-pr }}
+        github-token: ${{ inputs.github-token }}
+        cloud-url: ${{ inputs.pulumi-backend-url }}
+        secrets-provider: ${{ inputs.secrets-provider }}
+        parallel: ${{ inputs.parallel }}
+        message: ${{ inputs.message }}
+        expect-no-changes: ${{ inputs.expect-no-changes }}
+        diff: ${{ inputs.diff }}
+        replace: ${{ inputs.replace }}
+        target: ${{ inputs.target }}
+        target-dependents: ${{ inputs.target-dependents }}
+        refresh: ${{ inputs.refresh }}
+        upsert: ${{ inputs.upsert }}
+        edit-pr-comment: ${{ inputs.edit-pr-comment }}

--- a/action.yaml
+++ b/action.yaml
@@ -65,6 +65,7 @@ inputs:
   diff:
     description: 'Display operation as a rich diff showing the overall change'
     required: false
+    default: true
   replace:
     description: 'Specify resources to replace. Multiple resources can be specified one per line'
     required: false
@@ -78,7 +79,7 @@ inputs:
   refresh:
     description: 'Perform a stack refresh as part of the operation'
     required: false
-    default: 'false'
+    default: 'true'
   upsert:
     description: 'Create the stack if it currently does not exist'
     required: false
@@ -122,7 +123,7 @@ runs:
         work-dir: ${{ inputs.work-dir }}
         comment-on-pr: ${{ inputs.comment-on-pr }}
         github-token: ${{ inputs.github-token }}
-        cloud-url: ${{ inputs.pulumi-backend-url }}
+        cloud-url: ${{ inputs.cloud-url }}
         secrets-provider: ${{ inputs.secrets-provider }}
         parallel: ${{ inputs.parallel }}
         message: ${{ inputs.message }}

--- a/action.yaml
+++ b/action.yaml
@@ -38,7 +38,7 @@ inputs:
   comment-on-pr:
     description: 'If true, a comment will be created with results'
     required: false
-    default: 'false'
+    default: 'true'
   github-token:
     description: 'Github Token'
     required: false
@@ -65,7 +65,7 @@ inputs:
   diff:
     description: 'Display operation as a rich diff showing the overall change'
     required: false
-    default: true
+    default: 'true'
   replace:
     description: 'Specify resources to replace. Multiple resources can be specified one per line'
     required: false


### PR DESCRIPTION
This essentially wraps the official pulumi action, including all available inputs, but also installs go with caching, installs go dependencies, and configures AWS. This is done in a configurable manner such that in the future we can support other providers like gcp or azure, and other languages. We don't need those right now so the defaults are aws and go.